### PR TITLE
Add ability to specify colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Generate an avatar image from a user's initials, ideal for use as a meaningful g
 
 ![Example avatar](http://initials.me/jd)
 
+Changing the background or foreground color is as easy as passing the values through the query string
+
+![Example avatar](http://initials.me/jd?bg=SkyBlue&fg=White)
+
+You can even use the hex colors just remember to omit the '#' sign
+
+![Example avatar](http://initials.me/jd?bg=87CEEB&fg=FFF)
 
 ## Dependencies
 
@@ -86,4 +93,3 @@ http://www.gravatar.com/avatar/00000000000000000000000000000000?d=http%3A%2F%2Fi
 
 -   Image caching
 -   Font selection
--   Color selection

--- a/app.rb
+++ b/app.rb
@@ -21,6 +21,16 @@ class InitialsAvatar < Sinatra::Base
   get "/:initials.?:format?" do
     content_type "image/png"
 
+    hex_regex = /([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+
+    # Background color
+    background_color = params[:bg] ? "#{params[:bg]}" : "DBDBDB"
+    background_color = "#" << background_color if background_color =~ hex_regex
+    
+    # Fill / Foreground color
+    fill = params[:fg] ? "#{params[:fg]}" : "000000"
+    fill = "#" << fill if fill =~ hex_regex
+
     # Output/canvas sizes
     output_size = params[:s] ? params[:s].to_i : DEFAULT_OUTPUT_SIZE
     canvas_size = [output_size, MIN_CANVAS_SIZE].max
@@ -28,12 +38,12 @@ class InitialsAvatar < Sinatra::Base
     # Create the canvas
     img = Magick::Image.new(canvas_size, canvas_size) do
       self.format = "png"
-      self.background_color = "#DBDBDB"
+      self.background_color = background_color
     end
 
     # Create the text annotation
     Magick::Draw.new.annotate(img, canvas_size,canvas_size,0,canvas_size*Y_OFFSET, params[:initials][0..2].upcase) do
-      self.fill = "#000000"
+      self.fill = fill
       self.gravity = Magick::CenterGravity
       self.pointsize = canvas_size*FONT_RATIO
       self.font_weight = Magick::BoldWeight


### PR DESCRIPTION
I updated the readme to use the new query string parameters to set the background color and fill. The colors can be passed in via bg= and fg=, you can also pass in the hex of the colors omitting the hash and the image will be generated.
